### PR TITLE
fix: Resource List ISML

### DIFF
--- a/src/main/kotlin/com/intershop/gradle/isml/IsmlPlugin.kt
+++ b/src/main/kotlin/com/intershop/gradle/isml/IsmlPlugin.kt
@@ -24,7 +24,6 @@ import com.intershop.gradle.resourcelist.task.ResourceListFileTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaBasePlugin
-import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskProvider
@@ -102,7 +101,7 @@ open class IsmlPlugin : Plugin<Project> {
             extension.sourceSets.all { ismlSourceSet ->
 
                 val ismlTask = configureISMLTask(this, extension, ismlSourceSet)
-                val jspTask = cnfigureJSPTask(this, extension, ismlSourceSet, ismlTask)
+                val jspTask = configureJSPTask(this, extension, ismlSourceSet, ismlTask)
 
                 ismlSourceJar.configure {
                     it.from(ismlSourceSet.srcDir)
@@ -160,10 +159,10 @@ open class IsmlPlugin : Plugin<Project> {
 
     }
 
-    private fun cnfigureJSPTask(project: Project,
-                                extension: IsmlExtension,
-                                srcSet: IsmlSourceSet,
-                                ismlTask: TaskProvider<Isml2Jsp>): TaskProvider<Jsp2Java> {
+    private fun configureJSPTask(project: Project,
+                                 extension: IsmlExtension,
+                                 srcSet: IsmlSourceSet,
+                                 ismlTask: TaskProvider<Isml2Jsp>): TaskProvider<Jsp2Java> {
         return project.tasks.register(srcSet.getJspTaskName(), Jsp2Java::class.java) { jsptask ->
             jsptask.group = IsmlExtension.ISML_GROUP_NAME
 

--- a/src/main/kotlin/com/intershop/gradle/isml/IsmlPlugin.kt
+++ b/src/main/kotlin/com/intershop/gradle/isml/IsmlPlugin.kt
@@ -29,7 +29,6 @@ import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.language.jvm.tasks.ProcessResources
-import java.util.*
 
 /**
  * Plugin Class implementation.
@@ -225,11 +224,14 @@ open class IsmlPlugin : Plugin<Project> {
         return project.tasks.register("resourceListISML", ResourceListFileTask::class.java) { task ->
             task.description = "Creates a resource file with a list of ISML templates"
             task.group = IsmlExtension.ISML_GROUP_NAME
-            task.fileExtension = "jsp"
-            task.resourceListFileName =
-                String.format(Locale.getDefault() ,"resources/%s/isml/isml.resource", project.name)
+            task.fileExtension = "isml"
+            task.resourceListFileName = "resources/%s/isml/isml.resource".format(project.name)
             task.sourceSetName = "main"
-            task.include("**/**/*.jsp")
+            task.sourceFiles.from(
+                project.fileTree("%s/%s".format(IsmlExtension.MAIN_TEMPLATE_PATH, project.name)) {
+                    it.include("**/**/*.isml")
+                }
+            )
             task.outputDir.set(
                 project.layout.buildDirectory.dir(
                     "${ResourceListExtension.RESOURCELIST_OUTPUTPATH}/isml").get())

--- a/src/test/groovy/com/intershop/gradle/isml/CacheabilityKtsSpec.groovy
+++ b/src/test/groovy/com/intershop/gradle/isml/CacheabilityKtsSpec.groovy
@@ -243,6 +243,40 @@ class CacheabilityKtsSpec extends AbstractIntegrationKotlinSpec {
         gradleVersion << supportedGradleVersions
     }
 
+    def 'resourceListISML task should be cacheable'() {
+        given:
+        copyResources('test_isml')
+
+        buildFile << """
+            ${TASK_BASE_CONFIGURATION}
+        """.stripIndent()
+
+        when: 'First build populates the build cache'
+        def result1 = getPreparedGradleRunner()
+                .withArguments('resourceListISML', '--build-cache', '-s')
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        then: 'Task executes successfully and result is stored in cache'
+        result1.task(':resourceListISML').outcome == SUCCESS
+        new File(testProjectDir,
+                'build/generated/resourcelist/isml/resources/testCartridge/isml/isml.resource').exists()
+
+        when: 'Clean and rebuild using the build cache'
+        def result2 = getPreparedGradleRunner()
+                .withArguments('clean', 'resourceListISML', '--build-cache', '-s')
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        then: 'Task output is restored from cache'
+        result2.task(':resourceListISML').outcome == FROM_CACHE
+        new File(testProjectDir,
+                'build/generated/resourcelist/isml/resources/testCartridge/isml/isml.resource').exists()
+
+        where:
+        gradleVersion << supportedGradleVersions
+    }
+
     private static void copyDirectory(File source, File target) {
         def sourceRoot = source.toPath()
         def targetRoot = target.toPath()

--- a/src/test/groovy/com/intershop/gradle/isml/IsmlPluginKtsSpec.groovy
+++ b/src/test/groovy/com/intershop/gradle/isml/IsmlPluginKtsSpec.groovy
@@ -248,6 +248,108 @@ class IsmlPluginKtsSpec extends AbstractIntegrationKotlinSpec {
         tomcatVersion << getVersions('tomcat.version')
     }
 
+    def 'resourceListISML task generates isml.resource with correct content'() {
+        given:
+        copyResources('test_isml')
+
+        buildFile << """
+            plugins {
+                java
+                id("com.intershop.gradle.isml")
+            }
+
+            dependencies {
+                implementation(platform("org.apache.tomcat:tomcat-jasper:11.0.11"))
+                implementation(platform("org.slf4j:slf4j-api:1.7.36"))
+            }
+
+            repositories {
+                mavenCentral()
+                mavenLocal()
+            }
+        """.stripIndent()
+
+        settingsFile << """
+        rootProject.name="testCartridge"
+        """.stripIndent()
+
+        when:
+        def result = getPreparedGradleRunner()
+                .withArguments('resourceListISML', '-s')
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        File resourceFile = new File(testProjectDir,
+                'build/generated/resourcelist/isml/resources/testCartridge/isml/isml.resource')
+
+        then:
+        result.task(':resourceListISML').outcome == SUCCESS
+        resourceFile.exists()
+        resourceFile.text.contains('default.support.test')
+        // only .isml sources -> no .jsp entries must leak into the resource list
+        !resourceFile.text.contains('.jsp')
+
+        where:
+        gradleVersion << supportedGradleVersions
+    }
+
+    def 'resourceListISML task re-runs and includes new entry when an ISML file is added'() {
+        given:
+        copyResources('test_isml')
+
+        buildFile << """
+            plugins {
+                java
+                id("com.intershop.gradle.isml")
+            }
+
+            dependencies {
+                implementation(platform("org.apache.tomcat:tomcat-jasper:11.0.11"))
+                implementation(platform("org.slf4j:slf4j-api:1.7.36"))
+            }
+
+            repositories {
+                mavenCentral()
+                mavenLocal()
+            }
+        """.stripIndent()
+
+        settingsFile << """
+        rootProject.name="testCartridge"
+        """.stripIndent()
+
+        when: 'initial build'
+        def result1 = getPreparedGradleRunner()
+                .withArguments('resourceListISML', '-s')
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        then:
+        result1.task(':resourceListISML').outcome == SUCCESS
+
+        when: 'a new ISML template is added to the source directory'
+        File newIsml = new File(testProjectDir,
+                'src/main/isml/testCartridge/default/support/newTemplate.isml')
+        newIsml.parentFile.mkdirs()
+        newIsml << '<!---[New Template]--->\n<iscontent type="text/html" charset="UTF-8">\n'
+
+        def result2 = getPreparedGradleRunner()
+                .withArguments('resourceListISML', '-s')
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        File resourceFile = new File(testProjectDir,
+                'build/generated/resourcelist/isml/resources/testCartridge/isml/isml.resource')
+
+        then:
+        result2.task(':resourceListISML').outcome == SUCCESS
+        resourceFile.text.contains('default.support.test')
+        resourceFile.text.contains('default.support.newTemplate')
+
+        where:
+        gradleVersion << supportedGradleVersions
+    }
+
     def 'Test isml'() {
         given:
         copyResources('test_isml')
@@ -259,8 +361,8 @@ class IsmlPluginKtsSpec extends AbstractIntegrationKotlinSpec {
             }
 
             dependencies {
-                implementation(platform("org.apache.tomcat:tomcat-jasper:9.0.56"))
-                implementation(platform("org.slf4j:slf4j-api:1.7.32"))
+                implementation(platform("org.apache.tomcat:tomcat-jasper:11.0.11"))
+                implementation(platform("org.slf4j:slf4j-api:1.7.36"))
             }
             repositories {
                 mavenCentral()


### PR DESCRIPTION
**Integration Testing and Regression Bugfixing:**

* Added new integration tests to verify that the `resourceListISML` task and fixing the task itself:
  - Generates an `isml.resource` file containing only `.isml` entries and not `.jsp` entries
  - Correctly updates the resource list when new `.isml` files are added
  - Task remains cacheable, restoring output from the build cache as expected