### PR TITLE
feat: Isml2Jsp and Jsp2Java tasks configuration cache compatibility

### DIFF
--- a/src/main/kotlin/com/intershop/gradle/isml/IsmlPlugin.kt
+++ b/src/main/kotlin/com/intershop/gradle/isml/IsmlPlugin.kt
@@ -156,6 +156,8 @@ open class IsmlPlugin : Plugin<Project> {
             ismltask.inputDir.set(srcSet.srcDir)
             ismltask.outputDir.set( project.layout.buildDirectory.dir("generated/isml/${srcSet.name}") )
             ismltask.encoding.set(extension.encoding)
+
+            ismltask.ismlClasspathfiles.from(project.configurations.named(IsmlExtension.ISMLCOMPILER_CONFIGURATION_NAME))
         }
 
     }
@@ -184,6 +186,20 @@ open class IsmlPlugin : Plugin<Project> {
 
             jsptask.sourceSetName.set(extension.sourceSetName)
             jsptask.dependsOn(ismlTask)
+
+            jsptask.jspClasspathfiles.from(
+                project.configurations.named(IsmlExtension.JASPERCOMPILER_CONFIGURATION_NAME))
+
+            jsptask.classpathfiles.from(
+                extension.jspConfigurationName.flatMap { configName ->
+                    project.configurations.named(configName).map { config ->
+                        config.filter { f ->
+                            f.name.endsWith(".jar") &&
+                            !(f.name.startsWith("logback-classic") && !f.path.contains("wrapper"))
+                        }
+                    }
+                }
+            )
         }
     }
 

--- a/src/main/kotlin/com/intershop/gradle/isml/IsmlPlugin.kt
+++ b/src/main/kotlin/com/intershop/gradle/isml/IsmlPlugin.kt
@@ -24,7 +24,6 @@ import com.intershop.gradle.resourcelist.task.ResourceListFileTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaBasePlugin
-import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskProvider
@@ -117,6 +116,21 @@ open class IsmlPlugin : Plugin<Project> {
                 }
 
                 this.afterEvaluate {
+                    // Wire classpathfiles now that all plugins (including java) have been applied.
+                    // findByName returns null when runtimeClasspath does not exist (e.g. when the
+                    // java plugin is absent).
+                    val configName = extension.jspConfigurationName.get()
+                    configurations.findByName(configName)?.let { config ->
+                        jspTask.configure { task ->
+                            task.classpathfiles.from(
+                                config.filter { f ->
+                                    f.name.endsWith(".jar") &&
+                                    !(f.name.startsWith("logback-classic") && !f.path.contains("wrapper"))
+                                }
+                            )
+                        }
+                    }
+
                     plugins.withType(JavaBasePlugin::class.java) {
                         extensions.getByType(JavaPluginExtension::class.java).sourceSets.matching {
                             it.name == SourceSet.MAIN_SOURCE_SET_NAME
@@ -187,19 +201,7 @@ open class IsmlPlugin : Plugin<Project> {
             jsptask.sourceSetName.set(extension.sourceSetName)
             jsptask.dependsOn(ismlTask)
 
-            jsptask.jspClasspathfiles.from(
-                project.configurations.named(IsmlExtension.JASPERCOMPILER_CONFIGURATION_NAME))
-
-            jsptask.classpathfiles.from(
-                extension.jspConfigurationName.flatMap { configName ->
-                    project.configurations.named(configName).map { config ->
-                        config.filter { f ->
-                            f.name.endsWith(".jar") &&
-                            !(f.name.startsWith("logback-classic") && !f.path.contains("wrapper"))
-                        }
-                    }
-                }
-            )
+            jsptask.jspClasspathfiles.from(project.configurations.named(IsmlExtension.JASPERCOMPILER_CONFIGURATION_NAME))
         }
     }
 

--- a/src/main/kotlin/com/intershop/gradle/isml/tasks/Isml2Jsp.kt
+++ b/src/main/kotlin/com/intershop/gradle/isml/tasks/Isml2Jsp.kt
@@ -15,10 +15,9 @@
  */
 package com.intershop.gradle.isml.tasks
 
-import com.intershop.gradle.isml.extension.IsmlExtension
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
@@ -78,7 +77,7 @@ open class Isml2Jsp @Inject constructor(
     /**
      * Encoding configuration for ISML processing.
      *
-     * @property encodingProperty
+     * @property encoding
      */
     @get:Input
     val encoding: Property<String> = objectFactory.property(String::class.java)
@@ -89,11 +88,7 @@ open class Isml2Jsp @Inject constructor(
      * @property ismlClasspathfiles
      */
     @get:Classpath
-    val ismlClasspathfiles: FileCollection by lazy {
-        val returnFiles = project.files()
-        returnFiles.from(project.configurations.findByName(IsmlExtension.ISMLCOMPILER_CONFIGURATION_NAME))
-        returnFiles
-    }
+    val ismlClasspathfiles: ConfigurableFileCollection = objectFactory.fileCollection()
 
     /**
      * This is the task action and processes ISML files.

--- a/src/main/kotlin/com/intershop/gradle/isml/tasks/Jsp2Java.kt
+++ b/src/main/kotlin/com/intershop/gradle/isml/tasks/Jsp2Java.kt
@@ -17,8 +17,8 @@ package com.intershop.gradle.isml.tasks
 
 import com.intershop.gradle.isml.extension.IsmlExtension
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.model.ObjectFactory
@@ -59,7 +59,7 @@ open class Jsp2Java  @Inject constructor(
     val outputDir: DirectoryProperty = objectFactory.directoryProperty()
 
     /**
-     * Configuration, that is used for the the jsp2java compiilation.
+     * Configuration, that is used for the jsp2java compilation.
      *
      * @property jspConfigurationName
      */
@@ -86,7 +86,7 @@ open class Jsp2Java  @Inject constructor(
     /**
      * Encoding configuration for ISML processing.
      *
-     * @property encodingProperty
+     * @property encoding
      */
     @get:Input
     val encoding: Property<String> = objectFactory.property(String::class.java)
@@ -121,15 +121,10 @@ open class Jsp2Java  @Inject constructor(
     /**
      * Classpath files of the tools configuration.
      *
-     * @property classpathfiles
+     * @property jspClasspathfiles
      */
     @get:Classpath
-    val jspClasspathfiles : FileCollection by lazy {
-        val returnFiles = project.files()
-        // find files of original JASPER and Eclipse compiler
-        returnFiles.from(project.configurations.findByName(IsmlExtension.JASPERCOMPILER_CONFIGURATION_NAME))
-        returnFiles
-    }
+    val jspClasspathfiles: ConfigurableFileCollection = objectFactory.fileCollection()
 
     /**
      * Classpath files of the isml configuration.
@@ -137,15 +132,7 @@ open class Jsp2Java  @Inject constructor(
      * @property classpathfiles
      */
     @get:Classpath
-    val classpathfiles : FileCollection by lazy {
-        val returnFiles = project.files()
-
-        returnFiles.from(project.configurations.findByName(jspConfigurationName.get())?.filter {
-            it.name.endsWith(".jar") && ! (it.name.startsWith("logback-classic") && ! it.path.contains("wrapper"))
-        })
-
-        returnFiles
-    }
+    val classpathfiles: ConfigurableFileCollection = objectFactory.fileCollection()
 
     /**
      * This is the task action and processes ISML files.
@@ -161,9 +148,9 @@ open class Jsp2Java  @Inject constructor(
         webinf.parentFile.mkdirs()
         webinf.writeText(IsmlExtension.WEB_XML_CONTENT)
 
-        val classpathCollection = project.files(outputFolder, classpathfiles)
+        val classpathCollection = (listOf(outputFolder) + classpathfiles.files)
 
-        val runLoggerLevel = when(project.logging.level) {
+        val runLoggerLevel = when(logging.level) {
             LogLevel.INFO -> Level.INFO
             LogLevel.DEBUG -> Level.DEBUG
             LogLevel.ERROR -> Level.ERROR
@@ -185,7 +172,7 @@ open class Jsp2Java  @Inject constructor(
             it.targetCompatibility.set(targetCompatibility)
 
             it.logLevel.set(runLoggerLevel)
-            it.classpath.set(classpathCollection.asPath)
+            it.classpath.set(classpathCollection.joinToString(File.pathSeparator))
         }
 
         workerExecutor.await()

--- a/src/test/groovy/com/intershop/gradle/isml/ConfigurationCacheKtsSpec.groovy
+++ b/src/test/groovy/com/intershop/gradle/isml/ConfigurationCacheKtsSpec.groovy
@@ -1,0 +1,178 @@
+package com.intershop.gradle.isml
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
+
+import com.intershop.gradle.test.AbstractIntegrationKotlinSpec
+import spock.lang.Unroll
+
+/**
+ * Integration tests verifying that Isml2Jsp and Jsp2Java tasks are compatible with
+ * Gradle's configuration cache and that the cache is properly reused across runs.
+ */
+@Unroll
+class ConfigurationCacheKtsSpec extends AbstractIntegrationKotlinSpec {
+
+    // Shared build script used across tests
+    String BASE_BUILD = """
+        plugins {
+            java
+            id("com.intershop.gradle.isml")
+        }
+
+        dependencies {
+            implementation("org.apache.tomcat:tomcat-jasper:11.0.11")
+            implementation("org.slf4j:slf4j-api:1.7.36")
+        }
+
+        repositories {
+            mavenCentral()
+            mavenLocal()
+        }
+    """.stripIndent()
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = "testCartridge"
+        """.stripIndent()
+    }
+
+    def 'isml2jspMain succeeds on first run and reuses configuration cache on second run'() {
+        given:
+        copyResources('test_isml')
+        buildFile << BASE_BUILD
+
+        when: 'first run stores the configuration cache'
+        def result1 = getPreparedGradleRunner()
+                .withArguments('isml2jspMain', '--configuration-cache', '-s')
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        then: 'task executed successfully and cache entry was stored'
+        result1.task(':isml2jspMain').outcome == SUCCESS
+        result1.output.toLowerCase().contains('configuration cache entry stored')
+        new File(testProjectDir, 'build/generated/isml/main/default/support/test.jsp').exists()
+
+        when: 'second run should reuse the configuration cache'
+        def result2 = getPreparedGradleRunner()
+                .withArguments('isml2jspMain', '--configuration-cache', '-s')
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        then: 'configuration cache entry is reused and task is up-to-date'
+        result2.output.toLowerCase().contains('configuration cache entry reused')
+        result2.task(':isml2jspMain').outcome == UP_TO_DATE
+
+        where:
+        gradleVersion << supportedGradleVersions
+    }
+
+    def 'jsp2javaMain succeeds on first run and reuses configuration cache on second run'() {
+        given:
+        copyResources('test_isml')
+        buildFile << BASE_BUILD
+
+        when: 'first run stores the configuration cache'
+        def result1 = getPreparedGradleRunner()
+                .withArguments('jsp2javaMain', '--configuration-cache', '-s')
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        then: 'both tasks executed successfully and cache entry was stored'
+        result1.task(':isml2jspMain').outcome == SUCCESS
+        result1.task(':jsp2javaMain').outcome == SUCCESS
+        result1.output.toLowerCase().contains('configuration cache entry stored')
+        new File(testProjectDir, 'build/generated/jsp/main/org/apache/jsp/testCartridge/default_/support/test_jsp.java').exists()
+
+        when: 'second run should reuse the configuration cache'
+        def result2 = getPreparedGradleRunner()
+                .withArguments('jsp2javaMain', '--configuration-cache', '-s')
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        then: 'configuration cache entry is reused and tasks are up-to-date'
+        result2.output.toLowerCase().contains('configuration cache entry reused')
+        result2.task(':isml2jspMain').outcome == UP_TO_DATE
+        result2.task(':jsp2javaMain').outcome == UP_TO_DATE
+
+        where:
+        gradleVersion << supportedGradleVersions
+    }
+
+    def 'isml aggregate task succeeds on first run and reuses configuration cache on second run'() {
+        given:
+        copyResources('test_isml')
+        buildFile << BASE_BUILD
+
+        when: 'first run stores the configuration cache'
+        def result1 = getPreparedGradleRunner()
+                .withArguments('isml', '--configuration-cache', '-s')
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        then: 'all tasks executed successfully and cache entry was stored'
+        result1.task(':isml2jspMain').outcome == SUCCESS
+        result1.task(':jsp2javaMain').outcome == SUCCESS
+        result1.task(':isml').outcome == SUCCESS
+        result1.output.toLowerCase().contains('configuration cache entry stored')
+
+        when: 'second run reuses the configuration cache'
+        def result2 = getPreparedGradleRunner()
+                .withArguments('isml', '--configuration-cache', '-s')
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        then: 'configuration cache entry is reused, tasks are up-to-date'
+        result2.output.toLowerCase().contains('configuration cache entry reused')
+        result2.task(':isml2jspMain').outcome == UP_TO_DATE
+        result2.task(':jsp2javaMain').outcome == UP_TO_DATE
+
+        where:
+        gradleVersion << supportedGradleVersions
+    }
+
+    def 'configuration cache is invalidated and tasks re-execute when an ISML input file changes'() {
+        given:
+        copyResources('test_isml')
+        buildFile << BASE_BUILD
+
+        def ismlFile = new File(testProjectDir, 'src/main/isml/testCartridge/default/support/test.isml')
+
+        when: 'first run, stores configuration cache and executes tasks'
+        def result1 = getPreparedGradleRunner()
+                .withArguments('isml2jspMain', '--configuration-cache', '-s')
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        then:
+        result1.task(':isml2jspMain').outcome == SUCCESS
+        result1.output.toLowerCase().contains('configuration cache entry stored')
+
+        when: 'second run without changes, reuses cache, task is up-to-date'
+        def result2 = getPreparedGradleRunner()
+                .withArguments('isml2jspMain', '--configuration-cache', '-s')
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        then:
+        result2.output.toLowerCase().contains('configuration cache entry reused')
+        result2.task(':isml2jspMain').outcome == UP_TO_DATE
+
+        when: 'an input ISML file is modified'
+        ismlFile << '\n<%-- modified comment --%>'
+
+        and: 'third run, configuration cache is reused but task re-executes due to changed input'
+        def result3 = getPreparedGradleRunner()
+                .withArguments('isml2jspMain', '--configuration-cache', '-s')
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        then: 'the configuration cache entry is still reused (build scripts did not change)'
+        result3.output.toLowerCase().contains('configuration cache entry reused')
+        // the task itself must re-run because its input changed
+        result3.task(':isml2jspMain').outcome == SUCCESS
+
+        where:
+        gradleVersion << supportedGradleVersions
+    }
+}

--- a/src/test/groovy/com/intershop/gradle/isml/IsmlPluginTest.groovy
+++ b/src/test/groovy/com/intershop/gradle/isml/IsmlPluginTest.groovy
@@ -16,8 +16,11 @@
 
 package com.intershop.gradle.isml
 
+import com.intershop.gradle.isml.tasks.Isml2Jsp
+import com.intershop.gradle.isml.tasks.Jsp2Java
 import com.intershop.gradle.test.AbstractProjectSpec
 import org.gradle.api.Plugin
+import org.gradle.api.file.ConfigurableFileCollection
 
 class IsmlPluginTest extends AbstractProjectSpec {
 
@@ -53,5 +56,68 @@ class IsmlPluginTest extends AbstractProjectSpec {
 
         then:
         project.tasks.findByName("isml")
+    }
+
+    def 'Isml2Jsp.ismlClasspathfiles should be a ConfigurableFileCollection'() {
+        when:
+        plugin.apply(project)
+
+        then:
+        def task = project.tasks.findByName('isml2jspMain')
+        task instanceof Isml2Jsp
+        (task as Isml2Jsp).ismlClasspathfiles instanceof ConfigurableFileCollection
+    }
+
+    def 'Jsp2Java.jspClasspathfiles should be a ConfigurableFileCollection'() {
+        when:
+        plugin.apply(project)
+
+        then:
+        def task = project.tasks.findByName('jsp2javaMain')
+        task instanceof Jsp2Java
+        (task as Jsp2Java).jspClasspathfiles instanceof ConfigurableFileCollection
+    }
+
+    def 'Jsp2Java.classpathfiles should be a ConfigurableFileCollection'() {
+        when:
+        plugin.apply(project)
+
+        then:
+        def task = project.tasks.findByName('jsp2javaMain')
+        task instanceof Jsp2Java
+        (task as Jsp2Java).classpathfiles instanceof ConfigurableFileCollection
+    }
+
+    def 'Isml2Jsp.ismlClasspathfiles should be wired to the ismlCompiler configuration'() {
+        given:
+        plugin.apply(project)
+
+        // Add a local file directly to the ismlCompiler configuration
+        // If the collection is correctly wired, the file must appear when resolved
+        def fakeJar = File.createTempFile('fake-isml', '.jar')
+        fakeJar.deleteOnExit()
+        project.dependencies.add('ismlCompiler', project.files(fakeJar))
+
+        when:
+        def task = project.tasks.findByName('isml2jspMain') as Isml2Jsp
+
+        then: 'the file added to ismlCompiler is visible through the task classpath'
+        task.ismlClasspathfiles.files.contains(fakeJar)
+    }
+
+    def 'Jsp2Java.jspClasspathfiles should be wired to the jspCompiler configuration'() {
+        given:
+        plugin.apply(project)
+
+        // Add a local file directly to the jspCompiler configuration.
+        def fakeJar = File.createTempFile('fake-jsp', '.jar')
+        fakeJar.deleteOnExit()
+        project.dependencies.add('jspCompiler', project.files(fakeJar))
+
+        when:
+        def task = project.tasks.findByName('jsp2javaMain') as Jsp2Java
+
+        then: 'the file added to jspCompiler is visible through the task classpath'
+        task.jspClasspathfiles.files.contains(fakeJar)
     }
 }

--- a/src/test/groovy/com/intershop/gradle/isml/IsmlPluginTest.groovy
+++ b/src/test/groovy/com/intershop/gradle/isml/IsmlPluginTest.groovy
@@ -24,6 +24,19 @@ import org.gradle.api.file.ConfigurableFileCollection
 
 class IsmlPluginTest extends AbstractProjectSpec {
 
+    File fakeIsmlJar
+    File fakeJspJar
+
+    def setup() {
+        fakeIsmlJar = File.createTempFile('fake-isml', '.jar')
+        fakeJspJar = File.createTempFile('fake-jsp', '.jar')
+    }
+
+    def cleanup() {
+        fakeIsmlJar?.delete()
+        fakeJspJar?.delete()
+    }
+
     @Override
     Plugin getPlugin() {
         return new IsmlPlugin()
@@ -94,15 +107,13 @@ class IsmlPluginTest extends AbstractProjectSpec {
 
         // Add a local file directly to the ismlCompiler configuration
         // If the collection is correctly wired, the file must appear when resolved
-        def fakeJar = File.createTempFile('fake-isml', '.jar')
-        fakeJar.deleteOnExit()
-        project.dependencies.add('ismlCompiler', project.files(fakeJar))
+        project.dependencies.add('ismlCompiler', project.files(fakeIsmlJar))
 
         when:
         def task = project.tasks.findByName('isml2jspMain') as Isml2Jsp
 
         then: 'the file added to ismlCompiler is visible through the task classpath'
-        task.ismlClasspathfiles.files.contains(fakeJar)
+        task.ismlClasspathfiles.files.contains(fakeIsmlJar)
     }
 
     def 'Jsp2Java.jspClasspathfiles should be wired to the jspCompiler configuration'() {
@@ -110,14 +121,12 @@ class IsmlPluginTest extends AbstractProjectSpec {
         plugin.apply(project)
 
         // Add a local file directly to the jspCompiler configuration.
-        def fakeJar = File.createTempFile('fake-jsp', '.jar')
-        fakeJar.deleteOnExit()
-        project.dependencies.add('jspCompiler', project.files(fakeJar))
+        project.dependencies.add('jspCompiler', project.files(fakeJspJar))
 
         when:
         def task = project.tasks.findByName('jsp2javaMain') as Jsp2Java
 
         then: 'the file added to jspCompiler is visible through the task classpath'
-        task.jspClasspathfiles.files.contains(fakeJar)
+        task.jspClasspathfiles.files.contains(fakeJspJar)
     }
 }


### PR DESCRIPTION
The `Isml2Jsp` and `Jsp2Java` tasks have been improved with configuration cache compatibility. It replaces the use of `FileCollection` with `ConfigurableFileCollection` for classpath properties, wires these properties directly to their respective configurations and adds tests to verify the new behavior and configuration cache support.

Fixes also configuration cache errors like:
> Task `...:jsp2javaMain` of type `com.intershop.gradle.isml.tasks.Jsp2Java`: invocation of 'Task.project' at execution time is unsupported
